### PR TITLE
Back-button Workaround on iOS Chrome/Edge 

### DIFF
--- a/src/components/BlogNav.astro
+++ b/src/components/BlogNav.astro
@@ -1,3 +1,17 @@
-<div class="mt-4 text-red-400 font-bold">
-  <a href="/blog/" data-astro-prefetch>Back to Blogs</a>
-</div>
+<!--
+    Workaround for View Transitions back-button bug on iOS Chrome/Edge (history replaced, back exits site).
+    See: https://github.com/withastro/astro/issues/11919
+-->
+<nav
+  class="mt-6 pt-4 border-t border-line-primary"
+  aria-label="Back to blog list"
+>
+  <a
+    href="/blog/"
+    data-astro-prefetch
+    class="inline-flex items-center gap-2 text-red-500 hover:text-red-600 dark:text-red-400 dark:hover:text-red-300 font-semibold no-underline transition-colors md:mt-4"
+  >
+    <span class="text-xl leading-none" aria-hidden="true">←</span>
+    Back to Blogs
+  </a>
+</nav>

--- a/src/layouts/MarkdownPostLayout.astro
+++ b/src/layouts/MarkdownPostLayout.astro
@@ -32,6 +32,21 @@ const seo = {
 ---
 
 <BaseLayout pageTitle={frontmatter.title} layout="post" seo={seo}>
+  <!--
+    Workaround for View Transitions back-button bug on iOS Chrome/Edge (history replaced, back exits site).
+    See: https://github.com/withastro/astro/issues/11919
+  -->
+  <div class="mb-4 md:hidden">
+    <a
+      href="/blog/"
+      data-astro-prefetch
+      class="inline-flex items-center gap-2 text-red-500 hover:text-red-600 dark:text-red-400 dark:hover:text-red-300 font-semibold no-underline text-sm transition-colors"
+      aria-label="Back to blog list"
+    >
+      <span aria-hidden="true">←</span>
+      Back to Blogs
+    </a>
+  </div>
   <header class="pt-4 pb-6 border-b border-line-primary mb-6">
     <div class="flex flex-col gap-1 text-sm">
       <div class="flex items-baseline gap-2">


### PR DESCRIPTION
Implement workaround for View Transitions back-button bug on iOS Chrome/Edge in BlogNav and MarkdownPostLayout components.